### PR TITLE
fix: remove additional slash from twitter shortcode url generation

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -39,7 +39,7 @@ module.exports = function(eleventyConfig) {
     );
 
     eleventyConfig.addShortcode('tweet', (title, url) => {
-        const tweetContent = `${encodeURI(config.baseUrl)}/${url}`;
+        const tweetContent = `${encodeURI(config.baseUrl)}${url}`;
         const urlStr = `https://twitter.com/intent/tweet?text=${encodeURI(
             title
         )}&url=${tweetContent}`;


### PR DESCRIPTION
refs #48

Resolves issue where the URL generated for twitter has an extra slash.